### PR TITLE
Fix CI installs and stable tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,10 @@ jobs:
         cache: 'npm'
     
     - name: Install dependencies
-      run: npm install --legacy-peer-deps
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+        PUPPETEER_SKIP_DOWNLOAD: '1'
+      run: npm ci --legacy-peer-deps
       timeout-minutes: 10
     
     - name: Run type check

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -21,6 +21,9 @@ jobs:
         cache: 'npm'
     
     - name: Install dependencies
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+        PUPPETEER_SKIP_DOWNLOAD: '1'
       run: npm ci
     
     - name: Check for dependency vulnerabilities

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
         cache: 'npm'
     
     - name: Install dependencies
+      env:
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1'
+        PUPPETEER_SKIP_DOWNLOAD: '1'
       run: npm ci
     
     - name: Run tests

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
   testTimeout: 30000,
   maxWorkers: 4,
   moduleNameMapper: {
-    '^chalk$': '<rootDir>/node_modules/chalk/index.cjs',
+    '^chalk$': '<rootDir>/node_modules/chalk/source/index.js',
   },
   transformIgnorePatterns: [
     'node_modules/(?!(chalk)/)'

--- a/src/config/configManager.ts
+++ b/src/config/configManager.ts
@@ -9,7 +9,7 @@ export class ConfigManager {
   private configPath: string;
 
   constructor(configPath?: string) {
-    this.config = { ...defaultConfig };
+    this.config = JSON.parse(JSON.stringify(defaultConfig));
     this.configPath = configPath || path.join(process.cwd(), 'config.json');
   }
 
@@ -204,7 +204,7 @@ export class ConfigManager {
   }
 
   private mergeConfigs(base: IndexerConfig, updates: Partial<IndexerConfig>): IndexerConfig {
-    const merged = { ...base };
+    const merged: IndexerConfig = JSON.parse(JSON.stringify(base));
 
     // Handle nested objects
     if (updates.sources) {


### PR DESCRIPTION
## Summary
- skip heavy browser downloads during `npm ci`
- map chalk correctly for Jest
- deep copy default config in `ConfigManager`
- deep clone base config when merging

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6878d0cff0188324999764736f77a2d1