### PR TITLE
Fix TypeScript type error with unknown type

### DIFF
--- a/src/catalog/masterIndexer.ts
+++ b/src/catalog/masterIndexer.ts
@@ -1,4 +1,4 @@
-import { Level, MapSource } from '../types';
+import { Level, MapSource, IndexerResult } from '../types';
 import { CatalogManager } from './catalogManager';
 import { InternetArchiveIndexer } from '../indexers/archive/InternetArchiveIndexer';
 import { HognoseIndexer } from '../indexers/hognoseIndexer';
@@ -75,7 +75,7 @@ export class MasterIndexer {
       }
 
       // NOW create array of indexing promises AFTER Discord auth
-      const indexingPromises: Promise<{ source: string; result: unknown }>[] = [];
+      const indexingPromises: Promise<{ source: string; result: IndexerResult }>[] = [];
 
       // Add Internet Archive indexer
       if (this.internetArchiveIndexer) {


### PR DESCRIPTION
## Summary

This PR fixes the TypeScript type error that was causing GitHub Actions CI to fail.

## Problem

In the previous PR, we changed `any` to `unknown` to fix an ESLint warning, but this caused TypeScript errors because `unknown` type requires explicit type assertions or proper typing.

## Solution

- Import the `IndexerResult` interface from types
- Replace `unknown` with the proper `IndexerResult` type in the Promise type definition
- This provides proper type safety without using `any`

## Testing

- ? TypeScript compilation passes (`npm run type-check`)
- ? ESLint passes (`npm run lint:check`)
- ? Prettier formatting verified (`npm run format:check`)
- ? All unit tests pass (`npm test`)

This should fix the failing CI/CD pipeline.